### PR TITLE
Install gb dependencies before installing gb

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -60,6 +60,22 @@ fi
 export GOROOT=$cache/$ver/go
 PATH=$GOROOT/bin:$PATH
 
+# Install gb dependencies
+pkg_errors_src="$build/vendor/src/github.com/pkg/errors"
+
+if [[ -d "$pkg_errors_src" ]]
+then
+    echo "-----> Found a vendored version of pkg/errors"
+else
+    echo "-----> WARNING: vendored version of pkg/errors was not found!"
+    echo "Downloading master version from https://github.com/pkg/errors" | indent
+    mkdir -p "$pkg_errors_src"
+    curl -sL https://github.com/pkg/errors/archive/master.tar.gz \
+    | tar -C "$pkg_errors_src" --strip-components=1 -xzf -
+fi
+echo "-----> Installing gb dependencies"
+GOPATH="$build/vendor" go install github.com/pkg/errors/... 2>&1 | indent
+
 # Install gb
 gb_src="$build/vendor/src/github.com/constabulary/gb"
 if [[ -d "$gb_src" ]]

--- a/bin/compile
+++ b/bin/compile
@@ -60,22 +60,6 @@ fi
 export GOROOT=$cache/$ver/go
 PATH=$GOROOT/bin:$PATH
 
-# Install gb dependencies
-pkg_errors_src="$build/vendor/src/github.com/pkg/errors"
-
-if [[ -d "$pkg_errors_src" ]]
-then
-    echo "-----> Found a vendored version of pkg/errors"
-else
-    echo "-----> WARNING: vendored version of pkg/errors was not found!"
-    echo "Downloading master version from https://github.com/pkg/errors" | indent
-    mkdir -p "$pkg_errors_src"
-    curl -sL https://github.com/pkg/errors/archive/master.tar.gz \
-    | tar -C "$pkg_errors_src" --strip-components=1 -xzf -
-fi
-echo "-----> Installing gb dependencies"
-GOPATH="$build/vendor" go install github.com/pkg/errors/... 2>&1 | indent
-
 # Install gb
 gb_src="$build/vendor/src/github.com/constabulary/gb"
 if [[ -d "$gb_src" ]]
@@ -84,9 +68,7 @@ then
 else
     echo "-----> WARNING: vendored version of gb was not found!"
     echo "Downloading master version from https://github.com/constabulary/gb" | indent
-    mkdir -p "$gb_src"
-    curl -sL https://github.com/constabulary/gb/archive/master.tar.gz \
-    | tar -C "$gb_src" --strip-components=1 -xzf -
+    GOPATH="$build/vendor" go get -d github.com/constabulary/gb/... 2>&1 | indent
 fi
 echo "-----> Installing gb"
 GOPATH="$build/vendor" go install github.com/constabulary/gb/... 2>&1 | indent


### PR DESCRIPTION
Hey!

GB added dependency on an external package (pkg/errors) and our builds started failing. This pull request contains a proposed fix which helped us and may help others using this buildpack. Comments are appreciated.

Regards, Sergey.
